### PR TITLE
bson decode 解析到合理的格式

### DIFF
--- a/src/storage/dal/mongo/local/bson_register_decode.go
+++ b/src/storage/dal/mongo/local/bson_register_decode.go
@@ -1,0 +1,448 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package local
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"reflect"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+var (
+	dvd = bsoncodec.DefaultValueDecoders{}
+	// MapType use map decoder validation type
+	mapType   = reflect.TypeOf(make(map[string]interface{}))
+	ptBool    = reflect.TypeOf((*bool)(nil))
+	ptInt8    = reflect.TypeOf((*int8)(nil))
+	ptInt16   = reflect.TypeOf((*int16)(nil))
+	ptInt32   = reflect.TypeOf((*int32)(nil))
+	ptInt64   = reflect.TypeOf((*int64)(nil))
+	ptInt     = reflect.TypeOf((*int)(nil))
+	ptUint8   = reflect.TypeOf((*uint8)(nil))
+	ptUint16  = reflect.TypeOf((*uint16)(nil))
+	ptUint32  = reflect.TypeOf((*uint32)(nil))
+	ptUint64  = reflect.TypeOf((*uint64)(nil))
+	ptUint    = reflect.TypeOf((*uint)(nil))
+	ptFloat32 = reflect.TypeOf((*float32)(nil))
+	ptFloat64 = reflect.TypeOf((*float64)(nil))
+	ptString  = reflect.TypeOf((*string)(nil))
+
+	tBool    = reflect.TypeOf(false)
+	tFloat32 = reflect.TypeOf(float32(0))
+	tFloat64 = reflect.TypeOf(float64(0))
+	tInt     = reflect.TypeOf(int(0))
+	tInt8    = reflect.TypeOf(int8(0))
+	tInt16   = reflect.TypeOf(int16(0))
+	tInt32   = reflect.TypeOf(int32(0))
+	tInt64   = reflect.TypeOf(int64(0))
+	tString  = reflect.TypeOf("")
+	tTime    = reflect.TypeOf(time.Time{})
+	tUint    = reflect.TypeOf(uint(0))
+	tUint8   = reflect.TypeOf(uint8(0))
+	tUint16  = reflect.TypeOf(uint16(0))
+	tUint32  = reflect.TypeOf(uint32(0))
+	tUint64  = reflect.TypeOf(uint64(0))
+
+	tEmpty      = reflect.TypeOf((*interface{})(nil)).Elem()
+	tByteSlice  = reflect.TypeOf([]byte(nil))
+	tByte       = reflect.TypeOf(byte(0x00))
+	tURL        = reflect.TypeOf(url.URL{})
+	tJSONNumber = reflect.TypeOf(json.Number(""))
+
+	tValueMarshaler   = reflect.TypeOf((*bsoncodec.ValueMarshaler)(nil)).Elem()
+	tValueUnmarshaler = reflect.TypeOf((*bsoncodec.ValueUnmarshaler)(nil)).Elem()
+	tMarshaler        = reflect.TypeOf((*bsoncodec.Marshaler)(nil)).Elem()
+	tUnmarshaler      = reflect.TypeOf((*bsoncodec.Unmarshaler)(nil)).Elem()
+	tProxy            = reflect.TypeOf((*bsoncodec.Proxy)(nil)).Elem()
+
+	tBinary        = reflect.TypeOf(primitive.Binary{})
+	tUndefined     = reflect.TypeOf(primitive.Undefined{})
+	tOID           = reflect.TypeOf(primitive.ObjectID{})
+	tDateTime      = reflect.TypeOf(primitive.DateTime(0))
+	tNull          = reflect.TypeOf(primitive.Null{})
+	tRegex         = reflect.TypeOf(primitive.Regex{})
+	tCodeWithScope = reflect.TypeOf(primitive.CodeWithScope{})
+	tDBPointer     = reflect.TypeOf(primitive.DBPointer{})
+	tJavaScript    = reflect.TypeOf(primitive.JavaScript(""))
+	tSymbol        = reflect.TypeOf(primitive.Symbol(""))
+	tTimestamp     = reflect.TypeOf(primitive.Timestamp{})
+	tDecimal       = reflect.TypeOf(primitive.Decimal128{})
+	tMinKey        = reflect.TypeOf(primitive.MinKey{})
+	tMaxKey        = reflect.TypeOf(primitive.MaxKey{})
+	tD             = reflect.TypeOf(primitive.D{})
+	tA             = reflect.TypeOf(primitive.A{})
+	tE             = reflect.TypeOf(primitive.E{})
+
+	tCoreDocument = reflect.TypeOf(bsoncore.Document{})
+)
+
+func init() {
+
+	bsonRegister := bson.NewRegistryBuilder()
+	bsonRegister.RegisterDefaultDecoder(reflect.Map, bsoncodec.ValueDecoderFunc(MapDecodeValue))
+	bsonRegister.RegisterDefaultDecoder(reflect.Array, bsoncodec.ValueDecoderFunc(ArrayDecodeValue))
+	bsonRegister.RegisterDefaultDecoder(reflect.Slice, bsoncodec.ValueDecoderFunc(SliceDecodeValue))
+	bsonRegister.RegisterDefaultDecoder(reflect.Struct, defaultStructCodec)
+	bsonRegister.RegisterDecoder(tEmpty, bsoncodec.ValueDecoderFunc(EmptyInterfaceDecodeValue))
+
+	bson.DefaultRegistry = bsonRegister.Build()
+}
+
+// MapDecodeValue is the ValueDecoderFunc for map[string]* types.
+func MapDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+
+	if !val.CanSet() {
+		return bsoncodec.ValueDecoderError{Name: "MapDecodeValue", Kinds: []reflect.Kind{reflect.Map}, Received: val}
+	}
+
+	oldVal := val
+	if isInterface(val.Type()) {
+		val = reflect.New(mapType).Elem()
+	}
+
+	if val.Kind() != reflect.Map || val.Type().Key().Kind() != reflect.String {
+		return bsoncodec.ValueDecoderError{Name: "MapDecodeValue", Kinds: []reflect.Kind{reflect.Map}, Received: val}
+	}
+
+	switch vr.Type() {
+	case bsontype.Type(0), bsontype.EmbeddedDocument:
+	case bsontype.Null:
+		val.Set(reflect.Zero(val.Type()))
+		return vr.ReadNull()
+	default:
+		return fmt.Errorf("cannot decode %v into a %s", vr.Type(), val.Type())
+	}
+
+	dr, err := vr.ReadDocument()
+	if err != nil {
+		return err
+	}
+
+	if val.IsNil() {
+		val.Set(reflect.MakeMap(val.Type()))
+	}
+
+	eType := val.Type().Elem()
+	decoder, err := dc.LookupDecoder(eType)
+	if err != nil {
+		return err
+	}
+
+	if eType == tEmpty {
+		dc.Ancestor = val.Type()
+	}
+
+	keyType := val.Type().Key()
+	for {
+		key, vr, err := dr.ReadElement()
+		if err == bsonrw.ErrEOD {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		elem := reflect.New(eType).Elem()
+
+		err = decoder.DecodeValue(dc, vr, elem)
+		if err != nil {
+			return err
+		}
+
+		val.SetMapIndex(reflect.ValueOf(key).Convert(keyType), elem)
+	}
+	oldVal.Set(val)
+	return nil
+}
+
+// ArrayDecodeValue is the ValueDecoderFunc for array types.
+func ArrayDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+
+	if !val.IsValid() || val.Kind() != reflect.Array {
+		return bsoncodec.ValueDecoderError{Name: "ArrayDecodeValue", Kinds: []reflect.Kind{reflect.Array}, Received: val}
+	}
+
+	switch vr.Type() {
+	case bsontype.Array:
+	case bsontype.Type(0), bsontype.EmbeddedDocument:
+		if extendEmbeddedDocumentDecoder(vr.Type(), val) {
+			return MapDecodeValue(dc, vr, val)
+		} else if val.Type().Elem() != tE {
+			return fmt.Errorf("cannot decode document into %s", val.Type())
+		}
+	default:
+		return fmt.Errorf("cannot decode %v into an array", vr.Type())
+	}
+
+	var elemsFunc func(bsoncodec.DecodeContext, bsonrw.ValueReader, reflect.Value) ([]reflect.Value, error)
+	switch val.Type().Elem() {
+	case tE:
+		elemsFunc = decodeD
+	default:
+		elemsFunc = decodeDefault
+	}
+
+	elems, err := elemsFunc(dc, vr, val)
+	if err != nil {
+		return err
+	}
+
+	if len(elems) > val.Len() {
+		return fmt.Errorf("more elements returned in array than can fit inside %s", val.Type())
+	}
+
+	for idx, elem := range elems {
+		val.Index(idx).Set(elem)
+	}
+
+	return nil
+}
+
+// SliceDecodeValue is the ValueDecoderFunc for slice types.
+func SliceDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+
+	if !val.CanSet() || val.Kind() != reflect.Slice {
+		return bsoncodec.ValueDecoderError{Name: "SliceDecodeValue", Kinds: []reflect.Kind{reflect.Slice}, Received: val}
+	}
+
+	switch vr.Type() {
+	case bsontype.Array:
+	case bsontype.Null:
+		val.Set(reflect.Zero(val.Type()))
+		return vr.ReadNull()
+	case bsontype.Type(0), bsontype.EmbeddedDocument:
+		if extendEmbeddedDocumentDecoder(vr.Type(), val) {
+			return MapDecodeValue(dc, vr, val)
+		} else if val.Type().Elem() != tE {
+			return fmt.Errorf("cannot decode document into %s", val.Type())
+		}
+	default:
+		return fmt.Errorf("cannot decode %v into a slice", vr.Type())
+	}
+
+	var elemsFunc func(bsoncodec.DecodeContext, bsonrw.ValueReader, reflect.Value) ([]reflect.Value, error)
+	switch val.Type().Elem() {
+	case tE:
+		dc.Ancestor = val.Type()
+		elemsFunc = decodeD
+	default:
+		elemsFunc = decodeDefault
+	}
+
+	elems, err := elemsFunc(dc, vr, val)
+	if err != nil {
+		return err
+	}
+
+	if val.IsNil() {
+		val.Set(reflect.MakeSlice(val.Type(), 0, len(elems)))
+	}
+
+	val.SetLen(0)
+	val.Set(reflect.Append(val, elems...))
+
+	return nil
+}
+
+// EmptyInterfaceDecodeValue is the ValueDecoderFunc for interface{}.
+func EmptyInterfaceDecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+	if !val.CanSet() || val.Type() != tEmpty {
+		return bsoncodec.ValueDecoderError{Name: "EmptyInterfaceDecodeValue", Types: []reflect.Type{tEmpty}, Received: val}
+	}
+
+	if extendEmbeddedDocumentDecoder(vr.Type(), val) {
+		return MapDecodeValue(dc, vr, val)
+	}
+
+	rtype, err := dc.LookupTypeMapEntry(vr.Type())
+	if err != nil {
+		switch vr.Type() {
+		case bsontype.EmbeddedDocument:
+			if dc.Ancestor != nil {
+				rtype = dc.Ancestor
+				break
+			}
+			rtype = tD
+		case bsontype.Null:
+			val.Set(reflect.Zero(val.Type()))
+			return vr.ReadNull()
+		default:
+			return err
+		}
+	}
+
+	decoder, err := dc.LookupDecoder(rtype)
+	if err != nil {
+		return err
+	}
+
+	elem := reflect.New(rtype).Elem()
+	err = decoder.DecodeValue(dc, vr, elem)
+	if err != nil {
+		return err
+	}
+
+	val.Set(elem)
+	return nil
+}
+
+// IsInterface is interface
+func isInterface(t reflect.Type) bool {
+	if t.Kind() == reflect.Interface {
+		return true
+	}
+	return false
+}
+
+// documentDecodeUseMapStrInterface Whether to enable bson EmbeddedDocument with bson Unmarshal value of interface to use map[string]interface object parsing
+const documentDecodeUseMapStrInterface = true
+
+// IsEmbeddedDocument  is bsontype EmbeddedDocument
+func isEmbeddedDocument(bt bsontype.Type) bool {
+	if bt == bsontype.EmbeddedDocument {
+		return true
+	}
+	return false
+}
+
+// ExtendEmbeddedDocumentDecoder use map[string]interface decode bson  EmbeddedDocument to map[string]interface
+func extendEmbeddedDocumentDecoder(vrType bsontype.Type, val reflect.Value) bool {
+	/*
+		eg: test case
+		instanceMap := map[string]interface{}{"value": map[string]interface{}{"a": []int{12, 14}, "b": map[string]interface{}{"cc": 11}}}
+		instanceByte, err := bson.Marshal(instanceMap)
+		require.NoError(t, err)
+		var i map[string]interface{}
+		err = bson.Unmarshal(instanceByte, &i)
+		require.NoError(t, err)
+		result :
+		{"value":{"a":[12,14],"b":{"cc":11}}}
+		not  [{"Key":"value","Value":[{"Key":"a","Value":12},{"Key":"b","Value":122}]}]
+	*/
+
+	if documentDecodeUseMapStrInterface &&
+		(vrType == bsontype.Type(0) || isEmbeddedDocument(vrType)) &&
+		isInterface(val.Type()) {
+		return true
+	}
+	return false
+
+}
+
+// extendInterfaceDecode return documentDecodeUseMapStrInterface value
+func extendInterfaceDecode(val reflect.Value) bool {
+	/*
+		eg: test case
+		instanceMap := map[string]interface{}{"value": map[string]interface{}{"a": []int{12, 14}, "b": map[string]interface{}{"cc": 11}}}
+		instanceByte, err := bson.Marshal(instanceMap)
+		require.NoError(t, err)
+		var i map[string]interface{}
+		err = bson.Unmarshal(instanceByte, &i)
+		require.NoError(t, err)
+		result :
+		{"value":{"a":[12,14],"b":{"cc":11}}}
+		not  [{"Key":"value","Value":[{"Key":"a","Value":12},{"Key":"b","Value":122}]}]
+	*/
+	if documentDecodeUseMapStrInterface && isInterface(val.Type()) {
+		return true
+	}
+	return false
+}
+
+func decodeDefault(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) ([]reflect.Value, error) {
+	elems := make([]reflect.Value, 0)
+
+	ar, err := vr.ReadArray()
+	if err != nil {
+		return nil, err
+	}
+
+	eType := val.Type().Elem()
+
+	decoder, err := dc.LookupDecoder(eType)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		vr, err := ar.ReadValue()
+		if err == bsonrw.ErrEOA {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		elem := reflect.New(eType).Elem()
+
+		err = decoder.DecodeValue(dc, vr, elem)
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, elem)
+	}
+
+	return elems, nil
+}
+
+func decodeD(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, _ reflect.Value) ([]reflect.Value, error) {
+	switch vr.Type() {
+	case bsontype.Type(0), bsontype.EmbeddedDocument:
+	default:
+		return nil, fmt.Errorf("cannot decode %v into a D", vr.Type())
+	}
+
+	dr, err := vr.ReadDocument()
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeElemsFromDocumentReader(dc, dr)
+}
+
+func decodeElemsFromDocumentReader(dc bsoncodec.DecodeContext, dr bsonrw.DocumentReader) ([]reflect.Value, error) {
+	decoder, err := dc.LookupDecoder(tEmpty)
+	if err != nil {
+		return nil, err
+	}
+
+	elems := make([]reflect.Value, 0)
+	for {
+		key, vr, err := dr.ReadElement()
+		if err == bsonrw.ErrEOD {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		val := reflect.New(tEmpty).Elem()
+		err = decoder.DecodeValue(dc, vr, val)
+		if err != nil {
+			return nil, err
+		}
+
+		elems = append(elems, reflect.ValueOf(primitive.E{Key: key, Value: val.Interface()}))
+	}
+
+	return elems, nil
+}

--- a/src/storage/dal/mongo/local/bson_register_struct_decode.go
+++ b/src/storage/dal/mongo/local/bson_register_struct_decode.go
@@ -1,0 +1,308 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package local
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+
+	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+)
+
+var defaultStructCodec = &StructCodec{
+	cache:  make(map[reflect.Type]*structDescription),
+	parser: bsoncodec.DefaultStructTagParser,
+}
+
+// Zeroer allows custom struct types to implement a report of zero
+// state. All struct types that don't implement Zeroer or where IsZero
+// returns false are considered to be not zero.
+type Zeroer interface {
+	IsZero() bool
+}
+
+// StructCodec is the Codec used for struct values.
+type StructCodec struct {
+	cache  map[reflect.Type]*structDescription
+	l      sync.RWMutex
+	parser bsoncodec.StructTagParser
+}
+
+// NewStructCodec returns a StructCodec that uses p for struct tag parsing.
+func NewStructCodec(p bsoncodec.StructTagParser) (*StructCodec, error) {
+	if p == nil {
+		return nil, errors.New("a StructTagParser must be provided to NewStructCodec")
+	}
+
+	return &StructCodec{
+		cache:  make(map[reflect.Type]*structDescription),
+		parser: p,
+	}, nil
+}
+
+// DecodeValue implements the Codec interface.
+// By default, map types in val will not be cleared. If a map has existing key/value pairs, it will be extended with the new ones from vr.
+// For slices, the decoder will set the length of the slice to zero and append all elements. The underlying array will not be cleared.
+func (sc *StructCodec) DecodeValue(r bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+	if !val.CanSet() || val.Kind() != reflect.Struct {
+		return bsoncodec.ValueDecoderError{Name: "StructCodec.DecodeValue", Kinds: []reflect.Kind{reflect.Struct}, Received: val}
+	}
+
+	switch vr.Type() {
+	case bsontype.Type(0), bsontype.EmbeddedDocument:
+	default:
+		return fmt.Errorf("cannot decode %v into a %s", vr.Type(), val.Type())
+	}
+
+	sd, err := sc.describeStruct(r.Registry, val.Type())
+	if err != nil {
+		return err
+	}
+
+	var decoder bsoncodec.ValueDecoder
+	var inlineMap reflect.Value
+	if sd.inlineMap >= 0 {
+		inlineMap = val.Field(sd.inlineMap)
+		if inlineMap.IsNil() {
+			inlineMap.Set(reflect.MakeMap(inlineMap.Type()))
+		}
+		decoder, err = r.LookupDecoder(inlineMap.Type().Elem())
+		if err != nil {
+			return err
+		}
+	}
+
+	dr, err := vr.ReadDocument()
+	if err != nil {
+		return err
+	}
+
+	for {
+		name, vr, err := dr.ReadElement()
+		if err == bsonrw.ErrEOD {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		fd, exists := sd.fm[name]
+		if !exists {
+			if sd.inlineMap < 0 {
+				// The encoding/json package requires a flag to return on error for non-existent fields.
+				// This functionality seems appropriate for the struct codec.
+				err = vr.Skip()
+				if err != nil {
+					return err
+				}
+				continue
+			}
+
+			elem := reflect.New(inlineMap.Type().Elem()).Elem()
+			err = decoder.DecodeValue(r, vr, elem)
+			if err != nil {
+				return err
+			}
+
+			inlineMap.SetMapIndex(reflect.ValueOf(name), elem)
+			continue
+		}
+
+		var field reflect.Value
+		if fd.inline == nil {
+			field = val.Field(fd.idx)
+		} else {
+			field = val.FieldByIndex(fd.inline)
+		}
+		if extendEmbeddedDocumentDecoder(vr.Type(), field) {
+			decoder, err := r.LookupDecoder(mapType)
+			if err == nil {
+				fd.decoder = decoder
+			}
+		}
+
+		// compatible with null value
+		if vr.Type() == bsontype.Null {
+			if err := vr.ReadNull(); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if !field.CanSet() { // Being settable is a super set of being addressable.
+			return fmt.Errorf("cannot decode element '%s' into field %v; it is not settable", name, field)
+		}
+		if field.Kind() == reflect.Ptr && field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		field = field.Addr()
+
+		dctx := bsoncodec.DecodeContext{Registry: r.Registry, Truncate: fd.truncate}
+		if fd.decoder == nil {
+			return bsoncodec.ErrNoDecoder{Type: field.Elem().Type()}
+		}
+		if decoder, ok := fd.decoder.(bsoncodec.ValueDecoder); ok {
+			err = decoder.DecodeValue(dctx, vr, field.Elem())
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		err = fd.decoder.DecodeValue(dctx, vr, field)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sc *StructCodec) isZero(i interface{}) bool {
+	v := reflect.ValueOf(i)
+
+	// check the value validity
+	if !v.IsValid() {
+		return true
+	}
+
+	if z, ok := v.Interface().(Zeroer); ok && (v.Kind() != reflect.Ptr || !v.IsNil()) {
+		return z.IsZero()
+	}
+
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	return false
+}
+
+type structDescription struct {
+	fm        map[string]fieldDescription
+	fl        []fieldDescription
+	inlineMap int
+}
+
+type fieldDescription struct {
+	name      string
+	idx       int
+	omitEmpty bool
+	minSize   bool
+	truncate  bool
+	inline    []int
+	encoder   bsoncodec.ValueEncoder
+	decoder   bsoncodec.ValueDecoder
+}
+
+func (sc *StructCodec) describeStruct(r *bsoncodec.Registry, t reflect.Type) (*structDescription, error) {
+	// We need to analyze the struct, including getting the tags, collecting
+	// information about inlining, and create a map of the field name to the field.
+	sc.l.RLock()
+	ds, exists := sc.cache[t]
+	sc.l.RUnlock()
+	if exists {
+		return ds, nil
+	}
+
+	numFields := t.NumField()
+	sd := &structDescription{
+		fm:        make(map[string]fieldDescription, numFields),
+		fl:        make([]fieldDescription, 0, numFields),
+		inlineMap: -1,
+	}
+
+	for i := 0; i < numFields; i++ {
+		sf := t.Field(i)
+		if sf.PkgPath != "" {
+			// unexported, ignore
+			continue
+		}
+
+		encoder, err := r.LookupEncoder(sf.Type)
+		if err != nil {
+			encoder = nil
+		}
+		decoder, err := r.LookupDecoder(sf.Type)
+		if err != nil {
+			decoder = nil
+		}
+
+		description := fieldDescription{idx: i, encoder: encoder, decoder: decoder}
+
+		stags, err := sc.parser.ParseStructTags(sf)
+		if err != nil {
+			return nil, err
+		}
+		if stags.Skip {
+			continue
+		}
+		description.name = stags.Name
+		description.omitEmpty = stags.OmitEmpty
+		description.minSize = stags.MinSize
+		description.truncate = stags.Truncate
+
+		if stags.Inline || sf.Anonymous {
+			switch sf.Type.Kind() {
+			case reflect.Map:
+				if sd.inlineMap >= 0 {
+					return nil, errors.New("(struct " + t.String() + ") multiple inline maps")
+				}
+				if sf.Type.Key() != tString {
+					return nil, errors.New("(struct " + t.String() + ") inline map must have a string keys")
+				}
+				sd.inlineMap = description.idx
+			case reflect.Struct:
+				inlinesf, err := sc.describeStruct(r, sf.Type)
+				if err != nil {
+					return nil, err
+				}
+				for _, fd := range inlinesf.fl {
+					if _, exists := sd.fm[fd.name]; exists {
+						return nil, fmt.Errorf("(struct %s) duplicated key %s", t.String(), fd.name)
+					}
+					if fd.inline == nil {
+						fd.inline = []int{i, fd.idx}
+					} else {
+						fd.inline = append([]int{i}, fd.inline...)
+					}
+					sd.fm[fd.name] = fd
+					sd.fl = append(sd.fl, fd)
+				}
+			default:
+				return nil, fmt.Errorf("(struct %s) inline fields must be either a struct or a map", t.String())
+			}
+			continue
+		}
+
+		if _, exists := sd.fm[description.name]; exists {
+			return nil, fmt.Errorf("struct %s) duplicated key %s", t.String(), description.name)
+		}
+
+		sd.fm[description.name] = description
+		sd.fl = append(sd.fl, description)
+	}
+
+	sc.l.Lock()
+	sc.cache[t] = sd
+	sc.l.Unlock()
+
+	return sd, nil
+}


### PR DESCRIPTION
### 新加的功能:
- dal decode 数据的时候。 如果只为interface， 根据bson type将数据解析为map, slice， 使用替换bson register decode
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
