### PR TITLE
动态模型实例权限--注册部分

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -265,6 +265,8 @@ authServer:
   appCode: $auth_app_code
   #cmdb项目在蓝鲸权限中心的应用密钥
   appSecret: $auth_app_secret
+  #删除IAM多余模型的时间周期,最少为1m,不要忘记填入单位时(h),分(m),秒(s)
+  interval: 30m
 #cloudServer专属配置
 cloudServer:
   # 加密服务使用

--- a/src/ac/auth.go
+++ b/src/ac/auth.go
@@ -41,7 +41,13 @@ type AuthorizeInterface interface {
 	GetPermissionToApply(ctx context.Context, h http.Header, input []meta.ResourceAttribute) (*metadata.IamPermission, error)
 	RegisterResourceCreatorAction(ctx context.Context, h http.Header, input metadata.IamInstanceWithCreator) (
 		[]metadata.IamCreatorActionPolicy, error)
-
 	BatchRegisterResourceCreatorAction(ctx context.Context, h http.Header, input metadata.IamInstancesWithCreator) (
 		[]metadata.IamCreatorActionPolicy, error)
+	RegisterModelResourceTypes(ctx context.Context, h http.Header, input []metadata.Object) error
+	UnregisterModelResourceTypes(ctx context.Context, h http.Header, input []metadata.Object) error
+	RegisterModelInstanceSelections(ctx context.Context, h http.Header, input []metadata.Object) error
+	UnregisterModelInstanceSelections(ctx context.Context, h http.Header, input []metadata.Object) error
+	CreateModelInstanceActions(ctx context.Context, h http.Header, input []metadata.Object) error
+	DeleteModelInstanceActions(ctx context.Context, h http.Header, input []metadata.Object) error
+	UpdateModelInstanceActionGroups(ctx context.Context, h http.Header) error
 }

--- a/src/ac/iam/client.go
+++ b/src/ac/iam/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	codeNotFound = 1901404
+	CodeNotFound = 1901404
 )
 
 var (
@@ -74,12 +74,39 @@ func (c *iamClient) GetSystemInfo(ctx context.Context) (*SystemResp, error) {
 	}
 
 	if resp.Code != 0 {
-		if resp.Code == codeNotFound {
+		if resp.Code == CodeNotFound {
 			return resp, ErrNotFound
 		}
 		return nil, &AuthError{
 			RequestID: result.Header.Get(IamRequestHeader),
 			Reason:    fmt.Errorf("get system info failed, code: %d, msg:%s", resp.Code, resp.Message),
+		}
+	}
+
+	return resp, nil
+}
+
+func (c *iamClient) GetSystemDynamicInfo(ctx context.Context) (*SystemResp, error) {
+
+	resp := new(SystemResp)
+	result := c.client.Get().
+		SubResourcef("/api/v1/model/systems/%s/query", c.Config.SystemID).
+		WithContext(ctx).
+		WithHeaders(c.basicHeader).
+		WithParam("fields", "resource_types, actions, action_groups, instance_selections").
+		Body(nil).Do()
+	err := result.Into(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		if resp.Code == CodeNotFound {
+			return resp, ErrNotFound
+		}
+		return nil, &AuthError{
+			RequestID: result.Header.Get(IamRequestHeader),
+			Reason:    fmt.Errorf("get actions info failed, code: %d, msg:%s", resp.Code, resp.Message),
 		}
 	}
 

--- a/src/ac/iam/iam.go
+++ b/src/ac/iam/iam.go
@@ -33,7 +33,7 @@ import (
 )
 
 type Iam struct {
-	client *iamClient
+	Client *iamClient
 }
 
 func NewIam(tls *util.TLSClientConfig, cfg AuthConfig, reg prometheus.Registerer) (*Iam, error) {
@@ -60,11 +60,11 @@ func NewIam(tls *util.TLSClientConfig, cfg AuthConfig, reg prometheus.Registerer
 	header := http.Header{}
 	header.Set("Content-Type", "application/json")
 	header.Set("Accept", "application/json")
-	header.Set(iamAppCodeHeader, cfg.AppCode)
-	header.Set(iamAppSecretHeader, cfg.AppSecret)
+	header.Set(IamAppCodeHeader, cfg.AppCode)
+	header.Set(IamAppSecretHeader, cfg.AppSecret)
 
 	return &Iam{
-		client: &iamClient{
+		Client: &iamClient{
 			Config:      cfg,
 			client:      rest.NewRESTClient(c, ""),
 			basicHeader: header,
@@ -72,8 +72,8 @@ func NewIam(tls *util.TLSClientConfig, cfg AuthConfig, reg prometheus.Registerer
 	}, nil
 }
 
-func (i Iam) RegisterSystem(ctx context.Context, host string) error {
-	systemResp, err := i.client.GetSystemInfo(ctx)
+func (i Iam) RegisterSystem(ctx context.Context, host string, models []metadata.Object) error {
+	systemResp, err := i.Client.GetSystemInfo(ctx)
 	if err != nil && err != ErrNotFound {
 		blog.Errorf("get system info failed, error: %s", err.Error())
 		return err
@@ -90,14 +90,14 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 				Auth: "basic",
 			},
 		}
-		if err = i.client.RegisterSystem(ctx, sys); err != nil {
+		if err = i.Client.RegisterSystem(ctx, sys); err != nil {
 			blog.ErrorJSON("register system %s failed, error: %s", sys, err.Error())
 			return err
 		}
 		blog.V(5).Infof("register new system %+v succeed", sys)
 	} else if systemResp.Data.BaseInfo.ProviderConfig == nil || systemResp.Data.BaseInfo.ProviderConfig.Host != host {
 		// if iam registered cmdb system has no ProviderConfig or registered host config is different with current host config, update system host config
-		if err = i.client.UpdateSystemConfig(ctx, &SysConfig{Host: host}); err != nil {
+		if err = i.Client.UpdateSystemConfig(ctx, &SysConfig{Host: host}); err != nil {
 			blog.Errorf("update system host %s config failed, error: %s", host, err.Error())
 			return err
 		}
@@ -115,12 +115,12 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 		removedResourceTypeMap[resourceType.ID] = struct{}{}
 	}
 	newResourceTypes := make([]ResourceType, 0)
-	for _, resourceType := range GenerateResourceTypes() {
+	for _, resourceType := range GenerateResourceTypes(models) {
 		// registered resource type exist in current resource types, should not be removed
 		delete(removedResourceTypeMap, resourceType.ID)
 		// if current resource type is registered, update it, or else register it
 		if existResourceTypeMap[resourceType.ID] {
-			if err = i.client.UpdateResourcesTypes(ctx, resourceType); err != nil {
+			if err = i.Client.UpdateResourcesTypes(ctx, resourceType); err != nil {
 				blog.ErrorJSON("update resource type %s failed, error: %s, input resource type: %s", resourceType.ID, err.Error(), resourceType)
 				return err
 			}
@@ -129,7 +129,7 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 		}
 	}
 	if len(newResourceTypes) > 0 {
-		if err = i.client.RegisterResourcesTypes(ctx, newResourceTypes); err != nil {
+		if err = i.Client.RegisterResourcesTypes(ctx, newResourceTypes); err != nil {
 			blog.ErrorJSON("register resource types failed, error: %s, resource types: %s", err.Error(), newResourceTypes)
 			return err
 		}
@@ -142,12 +142,13 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 		removedInstanceSelectionMap[instanceSelection.ID] = struct{}{}
 	}
 	newInstanceSelections := make([]InstanceSelection, 0)
-	for _, resourceType := range GenerateInstanceSelections() {
+
+	for _, resourceType := range GenerateInstanceSelections(models) {
 		// registered instance selection exist in current instance selections, should not be removed
 		delete(removedInstanceSelectionMap, resourceType.ID)
 		// if current instance selection is registered, update it, or else register it
 		if existInstanceSelectionMap[resourceType.ID] {
-			if err = i.client.UpdateInstanceSelection(ctx, resourceType); err != nil {
+			if err = i.Client.UpdateInstanceSelection(ctx, resourceType); err != nil {
 				blog.ErrorJSON("update instance selection %s failed, error: %s, input resource type: %s", resourceType.ID, err.Error(), resourceType)
 				return err
 			}
@@ -156,7 +157,7 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 		}
 	}
 	if len(newInstanceSelections) > 0 {
-		if err = i.client.CreateInstanceSelection(ctx, newInstanceSelections); err != nil {
+		if err = i.Client.CreateInstanceSelection(ctx, newInstanceSelections); err != nil {
 			blog.ErrorJSON("register instance selections failed, error: %s, resource types: %s", err.Error(), newInstanceSelections)
 			return err
 		}
@@ -169,12 +170,12 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 		removedResourceActionMap[resourceAction.ID] = struct{}{}
 	}
 	newResourceActions := make([]ResourceAction, 0)
-	for _, resourceAction := range GenerateActions() {
+	for _, resourceAction := range GenerateActions(models) {
 		// registered resource action exist in current resource actions, should not be removed
 		delete(removedResourceActionMap, resourceAction.ID)
 		// if current resource action is registered, update it, or else register it
 		if existResourceActionMap[resourceAction.ID] {
-			if err = i.client.UpdateAction(ctx, resourceAction); err != nil {
+			if err = i.Client.UpdateAction(ctx, resourceAction); err != nil {
 				blog.ErrorJSON("update resource action %s failed, error: %s, input resource action: %s", resourceAction.ID, err.Error(), resourceAction)
 				return err
 			}
@@ -183,7 +184,7 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 		}
 	}
 	if len(newResourceActions) > 0 {
-		if err = i.client.CreateAction(ctx, newResourceActions); err != nil {
+		if err = i.Client.CreateAction(ctx, newResourceActions); err != nil {
 			blog.ErrorJSON("register resource actions failed, error: %s, resource actions: %s", err.Error(), newResourceActions)
 			return err
 		}
@@ -197,7 +198,7 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 			removedResourceActionIDs[idx] = resourceActionID
 			idx++
 		}
-		if err = i.client.DeleteAction(ctx, removedResourceActionIDs); err != nil {
+		if err = i.Client.DeleteAction(ctx, removedResourceActionIDs); err != nil {
 			blog.ErrorJSON("delete resource actions failed, error: %s, resource actions: %s", err.Error(), removedResourceActionIDs)
 			return err
 		}
@@ -209,7 +210,7 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 			removedInstanceSelectionIDs[idx] = resourceActionID
 			idx++
 		}
-		if err = i.client.DeleteInstanceSelection(ctx, removedInstanceSelectionIDs); err != nil {
+		if err = i.Client.DeleteInstanceSelection(ctx, removedInstanceSelectionIDs); err != nil {
 			blog.ErrorJSON("delete instance selections failed, error: %s, instance selections: %s", err.Error(), removedInstanceSelectionIDs)
 			return err
 		}
@@ -221,21 +222,21 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 			removedResourceTypeIDs[idx] = resourceType
 			idx++
 		}
-		if err = i.client.DeleteResourcesTypes(ctx, removedResourceTypeIDs); err != nil {
+		if err = i.Client.DeleteResourcesTypes(ctx, removedResourceTypeIDs); err != nil {
 			blog.ErrorJSON("delete resource types failed, error: %s, resource types: %s", err.Error(), removedResourceTypeIDs)
 			return err
 		}
 	}
 
 	// register or update resource action groups
-	actionGroups := GenerateActionGroups()
+	actionGroups := GenerateActionGroups(models)
 	if len(systemResp.Data.ActionGroups) == 0 {
-		if err = i.client.RegisterActionGroups(ctx, actionGroups); err != nil {
+		if err = i.Client.RegisterActionGroups(ctx, actionGroups); err != nil {
 			blog.ErrorJSON("register action groups failed, error: %s, action groups: %s", err.Error(), actionGroups)
 			return err
 		}
 	} else {
-		if err = i.client.UpdateActionGroups(ctx, actionGroups); err != nil {
+		if err = i.Client.UpdateActionGroups(ctx, actionGroups); err != nil {
 			blog.ErrorJSON("update action groups failed, error: %s, action groups: %s", err.Error(), actionGroups)
 			return err
 		}
@@ -244,12 +245,12 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 	// register or update resource creator actions
 	resourceCreatorActions := GenerateResourceCreatorActions()
 	if len(systemResp.Data.ResourceCreatorActions.Config) == 0 {
-		if err = i.client.RegisterResourceCreatorActions(ctx, resourceCreatorActions); err != nil {
+		if err = i.Client.RegisterResourceCreatorActions(ctx, resourceCreatorActions); err != nil {
 			blog.ErrorJSON("register resource creator actions failed, error: %s, resource creator actions: %s", err.Error(), resourceCreatorActions)
 			return err
 		}
 	} else {
-		if err = i.client.UpdateResourceCreatorActions(ctx, resourceCreatorActions); err != nil {
+		if err = i.Client.UpdateResourceCreatorActions(ctx, resourceCreatorActions); err != nil {
 			blog.ErrorJSON("update resource creator actions failed, error: %s, resource creator actions: %s", err.Error(), resourceCreatorActions)
 			return err
 		}
@@ -258,12 +259,12 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 	// register or update common actions
 	commonActions := GenerateCommonActions()
 	if len(systemResp.Data.CommonActions) == 0 {
-		if err = i.client.RegisterCommonActions(ctx, commonActions); err != nil {
+		if err = i.Client.RegisterCommonActions(ctx, commonActions); err != nil {
 			blog.ErrorJSON("register common actions failed, error: %s, common actions: %s", err.Error(), commonActions)
 			return err
 		}
 	} else {
-		if err = i.client.UpdateCommonActions(ctx, commonActions); err != nil {
+		if err = i.Client.UpdateCommonActions(ctx, commonActions); err != nil {
 			blog.ErrorJSON("update common actions failed, error: %s, common actions: %s", err.Error(), commonActions)
 			return err
 		}
@@ -411,4 +412,32 @@ func (a *authorizer) BatchRegisterResourceCreatorAction(ctx context.Context, h h
 	[]metadata.IamCreatorActionPolicy, error) {
 
 	return a.authClientSet.BatchRegisterResourceCreatorAction(ctx, h, input)
+}
+
+func (a *authorizer) RegisterModelResourceTypes(ctx context.Context, h http.Header, input []metadata.Object) error {
+	return a.authClientSet.RegisterModelResourceTypes(ctx, h, input)
+}
+
+func (a *authorizer) UnregisterModelResourceTypes(ctx context.Context, h http.Header, input []metadata.Object) error {
+	return a.authClientSet.UnregisterModelResourceTypes(ctx, h, input)
+}
+
+func (a *authorizer) RegisterModelInstanceSelections(ctx context.Context, h http.Header, input []metadata.Object) error {
+	return a.authClientSet.RegisterModelInstanceSelections(ctx, h, input)
+}
+
+func (a *authorizer) UnregisterModelInstanceSelections(ctx context.Context, h http.Header, input []metadata.Object) error {
+	return a.authClientSet.UnregisterModelInstanceSelections(ctx, h, input)
+}
+
+func (a *authorizer) CreateModelInstanceActions(ctx context.Context, h http.Header, input []metadata.Object) error {
+	return a.authClientSet.CreateModelInstanceActions(ctx, h, input)
+}
+
+func (a *authorizer) DeleteModelInstanceActions(ctx context.Context, h http.Header, input []metadata.Object) error {
+	return a.authClientSet.DeleteModelInstanceActions(ctx, h, input)
+}
+
+func (a *authorizer) UpdateModelInstanceActionGroups(ctx context.Context, h http.Header) error {
+	return a.authClientSet.UpdateModelInstanceActionGroups(ctx, h)
 }

--- a/src/ac/iam/initial_action_groups.go
+++ b/src/ac/iam/initial_action_groups.go
@@ -12,8 +12,20 @@
 
 package iam
 
+import "configcenter/src/common/metadata"
+
 // GenerateActionGroups generate all the resource action groups registered to IAM.
-func GenerateActionGroups() []ActionGroup {
+func GenerateActionGroups(objects []metadata.Object) []ActionGroup {
+	ActionGroups := GenerateStaticActionGroups()
+
+	// generate model instance manage action groups, contains model instance related actions which are dynamic
+	ActionGroups = append(ActionGroups, GenModelInstanceManageActionGroups(objects)...)
+
+	return ActionGroups
+}
+
+// GenerateStaticActionGroups generate all the static resource action groups.
+func GenerateStaticActionGroups() []ActionGroup {
 	ActionGroups := make([]ActionGroup, 0)
 
 	// generate business manage action groups, contains business related actions
@@ -228,21 +240,6 @@ func genResourceManageActionGroups() []ActionGroup {
 					},
 				},
 				{
-					Name:   "实例",
-					NameEn: "Configuration Instance",
-					Actions: []ActionWithID{
-						{
-							ID: CreateSysInstance,
-						},
-						{
-							ID: EditSysInstance,
-						},
-						{
-							ID: DeleteSysInstance,
-						},
-					},
-				},
-				{
 					Name:   "云账户",
 					NameEn: "Cloud Account",
 					Actions: []ActionWithID{
@@ -347,7 +344,7 @@ func genModelManageActionGroups() []ActionGroup {
 	return []ActionGroup{
 		{
 			Name:   "模型管理",
-			NameEn: "Model Mange",
+			NameEn: "Model Manage",
 			SubGroups: []ActionGroup{
 				{
 					Name:   "模型分组",
@@ -407,6 +404,20 @@ func genModelManageActionGroups() []ActionGroup {
 					},
 				},
 			},
+		},
+	}
+}
+
+func GenModelInstanceManageActionGroups(objects []metadata.Object) []ActionGroup {
+	subGroups := []ActionGroup{}
+	for _, obj := range objects {
+		subGroups = append(subGroups, MakeDynamicActionSubGroup(obj))
+	}
+	return []ActionGroup{
+		{
+			Name:      "模型实例管理",
+			NameEn:    "Model instance Manage",
+			SubGroups: subGroups,
 		},
 	}
 }

--- a/src/ac/iam/initial_instance_selections.go
+++ b/src/ac/iam/initial_instance_selections.go
@@ -12,6 +12,8 @@
 
 package iam
 
+import "configcenter/src/common/metadata"
+
 var (
 	businessChain = ResourceChain{
 		SystemID: SystemIDCMDB,
@@ -20,7 +22,13 @@ var (
 )
 
 // GenerateInstanceSelections generate all the instance selections registered to IAM.
-func GenerateInstanceSelections() []InstanceSelection {
+func GenerateInstanceSelections(models []metadata.Object) []InstanceSelection {
+	instSelections := GenerateStaticInstanceSelections()
+	instSelections = append(instSelections, GenDynamicInstanceSelectionWithModel(models)...)
+	return instSelections
+}
+
+func GenerateStaticInstanceSelections() []InstanceSelection {
 	return []InstanceSelection{
 		{
 			ID:                BusinessSelection,
@@ -136,21 +144,6 @@ func GenerateInstanceSelections() []InstanceSelection {
 				{
 					SystemID: SystemIDCMDB,
 					ID:       SysCloudArea,
-				},
-			},
-		},
-		{
-			ID:     SysInstanceSelection,
-			Name:   "实例列表",
-			NameEn: "Instance List",
-			ResourceTypeChain: []ResourceChain{
-				{
-					SystemID: SystemIDCMDB,
-					ID:       SysInstanceModel,
-				},
-				{
-					SystemID: SystemIDCMDB,
-					ID:       SysInstance,
 				},
 			},
 		},

--- a/src/ac/iam/initial_resources.go
+++ b/src/ac/iam/initial_resources.go
@@ -12,6 +12,8 @@
 
 package iam
 
+import "configcenter/src/common/metadata"
+
 var (
 	businessParent = Parent{
 		SystemID:   SystemIDCMDB,
@@ -48,7 +50,18 @@ var ResourceTypeIDMap = map[TypeID]string{
 }
 
 // GenerateResourceTypes generate all the resource types registered to IAM.
-func GenerateResourceTypes() []ResourceType {
+func GenerateResourceTypes(models []metadata.Object) []ResourceType {
+	resourceTypeList := make([]ResourceType, 0)
+
+	// add public and business resources
+	resourceTypeList = append(resourceTypeList, GenerateStaticResourceTypes()...)
+
+	// add dynamic resources
+	resourceTypeList = append(resourceTypeList, GenDynamicResourceTypeWithModel(models)...)
+	return resourceTypeList
+}
+
+func GenerateStaticResourceTypes() []ResourceType {
 	resourceTypeList := make([]ResourceType, 0)
 
 	// add public resources
@@ -56,14 +69,13 @@ func GenerateResourceTypes() []ResourceType {
 
 	// add business resources
 	resourceTypeList = append(resourceTypeList, genBusinessResources()...)
-
 	return resourceTypeList
 }
 
 // GetResourceParentMap generate resource types' mapping to parents.
 func GetResourceParentMap() map[TypeID][]TypeID {
 	resourceParentMap := make(map[TypeID][]TypeID, 0)
-	for _, resourceType := range GenerateResourceTypes() {
+	for _, resourceType := range GenerateStaticResourceTypes() {
 		for _, parent := range resourceType.Parents {
 			resourceParentMap[resourceType.ID] = append(resourceParentMap[resourceType.ID], parent.ResourceID)
 		}
@@ -293,18 +305,18 @@ func genPublicResources() []ResourceType {
 			},
 			Version: 1,
 		},
-		{
-			ID:            SysInstanceModel,
-			Name:          ResourceTypeIDMap[SysInstanceModel],
-			NameEn:        "InstanceModel",
-			Description:   "实例模型",
-			DescriptionEn: "instance model",
-			Parents:       nil,
-			ProviderConfig: ResourceConfig{
-				Path: "/auth/v3/find/resource",
-			},
-			Version: 1,
-		},
+		//{
+		//	ID:            SysInstanceModel,
+		//	Name:          ResourceTypeIDMap[SysInstanceModel],
+		//	NameEn:        "InstanceModel",
+		//	Description:   "实例模型",
+		//	DescriptionEn: "instance model",
+		//	Parents:       nil,
+		//	ProviderConfig: ResourceConfig{
+		//		Path: "/auth/v3/find/resource",
+		//	},
+		//	Version: 1,
+		//},
 		{
 			ID:            SysModel,
 			Name:          ResourceTypeIDMap[SysModel],

--- a/src/apimachinery/authserver/api.go
+++ b/src/apimachinery/authserver/api.go
@@ -197,3 +197,157 @@ func (a *authServer) BatchRegisterResourceCreatorAction(ctx context.Context, h h
 
 	return response.Data, nil
 }
+
+func (a *authServer) RegisterModelResourceTypes(ctx context.Context, h http.Header, input []metadata.Object) error {
+	resp := new(metadata.Response)
+	subPath := "/register/model_resource_types"
+
+	err := a.client.Post().
+		WithContext(ctx).
+		Body(input).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return errors.CCHttpError
+	}
+	if resp.Code != 0 {
+		return resp.CCError()
+	}
+
+	return nil
+}
+
+func (a *authServer) UnregisterModelResourceTypes(ctx context.Context, h http.Header, input []metadata.Object) error {
+	resp := new(metadata.Response)
+	subPath := "/unregister/model_resource_types"
+
+	err := a.client.Post().
+		WithContext(ctx).
+		Body(input).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return errors.CCHttpError
+	}
+	if resp.Code != 0 {
+		return resp.CCError()
+	}
+
+	return nil
+}
+
+func (a *authServer) RegisterModelInstanceSelections(ctx context.Context, h http.Header, input []metadata.Object) error {
+	resp := new(metadata.Response)
+	subPath := "/register/model_instance_selections"
+
+	err := a.client.Post().
+		WithContext(ctx).
+		Body(input).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return errors.CCHttpError
+	}
+	if resp.Code != 0 {
+		return resp.CCError()
+	}
+
+	return nil
+}
+
+func (a *authServer) UnregisterModelInstanceSelections(ctx context.Context, h http.Header, input []metadata.Object) error {
+	resp := new(metadata.Response)
+	subPath := "/unregister/model_instance_selections"
+
+	err := a.client.Post().
+		WithContext(ctx).
+		Body(input).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return errors.CCHttpError
+	}
+	if resp.Code != 0 {
+		return resp.CCError()
+	}
+
+	return nil
+}
+
+func (a *authServer) CreateModelInstanceActions(ctx context.Context, h http.Header, input []metadata.Object) error {
+	resp := new(metadata.Response)
+	subPath := "/create/model_instance_actions"
+
+	err := a.client.Post().
+		WithContext(ctx).
+		Body(input).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return errors.CCHttpError
+	}
+	if resp.Code != 0 {
+		return resp.CCError()
+	}
+
+	return nil
+}
+
+func (a *authServer) DeleteModelInstanceActions(ctx context.Context, h http.Header, input []metadata.Object) error {
+	resp := new(metadata.Response)
+	subPath := "/delete/model_instance_actions"
+
+	err := a.client.Post().
+		WithContext(ctx).
+		Body(input).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return errors.CCHttpError
+	}
+	if resp.Code != 0 {
+		return resp.CCError()
+	}
+
+	return nil
+}
+
+func (a *authServer) UpdateModelInstanceActionGroups(ctx context.Context, h http.Header) error {
+	resp := new(metadata.Response)
+	subPath := "/update/model_instance_action_groups"
+
+	err := a.client.Post().
+		WithContext(ctx).
+		Body(nil).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return errors.CCHttpError
+	}
+	if resp.Code != 0 {
+		return resp.CCError()
+	}
+
+	return nil
+}

--- a/src/apimachinery/authserver/authserver.go
+++ b/src/apimachinery/authserver/authserver.go
@@ -34,6 +34,13 @@ type AuthServerClientInterface interface {
 		[]metadata.IamCreatorActionPolicy, error)
 	BatchRegisterResourceCreatorAction(ctx context.Context, h http.Header, input metadata.IamInstancesWithCreator) (
 		[]metadata.IamCreatorActionPolicy, error)
+	RegisterModelResourceTypes(ctx context.Context, h http.Header, input []metadata.Object) error
+	UnregisterModelResourceTypes(ctx context.Context, h http.Header, input []metadata.Object) error
+	RegisterModelInstanceSelections(ctx context.Context, h http.Header, input []metadata.Object) error
+	UnregisterModelInstanceSelections(ctx context.Context, h http.Header, input []metadata.Object) error
+	CreateModelInstanceActions(ctx context.Context, h http.Header, input []metadata.Object) error
+	DeleteModelInstanceActions(ctx context.Context, h http.Header, input []metadata.Object) error
+	UpdateModelInstanceActionGroups(ctx context.Context, h http.Header) error
 }
 
 func NewAuthServerClientInterface(c *util.Capability, version string) AuthServerClientInterface {

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -422,6 +422,16 @@ func Int(key string) (int, error) {
 	return 0, err.New("config not found")
 }
 
+// Int return the int value of the configuration information according to the key.
+func Duration(key string) (time.Duration, error) {
+	confLock.RLock()
+	defer confLock.RUnlock()
+	if commonParser != nil && commonParser.isSet(key) {
+		return commonParser.getDuration(key), nil
+	}
+	return 0, err.New("config not found")
+}
+
 // Bool return the bool value of the configuration information according to the key.
 func Bool(key string) (bool, error) {
 	confLock.RLock()
@@ -463,6 +473,7 @@ type Parser interface {
 	GetInt(string) int
 	GetUint64(string) uint64
 	GetBool(string) bool
+	GetDuration(string) time.Duration
 	IsSet(path string) bool
 }
 
@@ -507,6 +518,10 @@ func (vp *viperParser) getUint64(path string) uint64 {
 
 func (vp *viperParser) getBool(path string) bool {
 	return vp.parser.GetBool(path)
+}
+
+func (vp *viperParser) getDuration(path string) time.Duration {
+	return vp.parser.GetDuration(path)
 }
 
 func (vp *viperParser) isSet(path string) bool {

--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -1091,6 +1091,8 @@ const (
 	BKSynchronizeDataTaskDefaultUser = "synchronize task user"
 
 	BKCloudSyncUser = "cloud_sync_user"
+
+	BKAuthUser = "auth_sync_user"
 )
 
 const (

--- a/src/scene_server/admin_server/service/authcenter.go
+++ b/src/scene_server/admin_server/service/authcenter.go
@@ -14,11 +14,13 @@ package service
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"configcenter/src/common"
 	"configcenter/src/common/auth"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/condition"
 	"configcenter/src/common/metadata"
 	"configcenter/src/common/util"
 
@@ -50,7 +52,15 @@ func (s *Service) InitAuthCenter(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	if err := s.iam.RegisterSystem(s.ctx, param.Host); err != nil {
+	// 由于模型实例的编辑&删除拆分为实例级别, 需要先拿到当前已存在的模型, 再进行相应的IAM注册操作
+	models, err := s.CollectObjectsNotPre(rHeader)
+	if err != nil {
+		blog.Errorf("init iam failed, collect notPre-models failed, err: %s, rid:%s", err.Error(), rid)
+		_ = resp.WriteError(http.StatusBadRequest, &metadata.RespError{Msg: defErr.CCError(common.CCErrCommDBSelectFailed)})
+		return
+	}
+
+	if err := s.iam.RegisterSystem(s.ctx, param.Host, models); err != nil {
 		blog.Errorf("init iam failed, err: %+v, rid: %s", err, rid)
 		result := &metadata.RespError{
 			Msg: defErr.CCErrorf(common.CCErrCommInitAuthCenterFailed, err.Error()),
@@ -60,4 +70,28 @@ func (s *Service) InitAuthCenter(req *restful.Request, resp *restful.Response) {
 	}
 
 	_ = resp.WriteEntity(metadata.NewSuccessResp(nil))
+}
+
+// collectObjectsNotPre collect objects which are custom.
+func (s *Service) CollectObjectsNotPre(header http.Header) ([]metadata.Object, error) {
+	// get model
+	cond := condition.CreateCondition().Field(common.BKIsPre).Eq(false)
+	cond.SetFields([]string{common.BKObjIDField, common.BKObjNameField, common.BKFieldID})
+	fCond := cond.ToMapStr()
+	queryCond := &metadata.QueryCondition{Condition: fCond}
+
+	resp, err := s.CoreAPI.CoreService().Model().ReadModel(s.ctx, header, queryCond)
+	if err != nil {
+		return nil, fmt.Errorf("get custom models failed, err: %+v", err)
+	}
+	if len(resp.Data.Info) == 0 {
+		blog.Info("get custom models, custom models not found")
+	}
+
+	objects := make([]metadata.Object, 0)
+	for _, item := range resp.Data.Info {
+		objects = append(objects, item.Spec)
+	}
+
+	return objects, nil
 }

--- a/src/scene_server/auth_server/logics/list_instance.go
+++ b/src/scene_server/auth_server/logics/list_instance.go
@@ -149,6 +149,7 @@ func (lgc *Logics) ListBusinessInstance(kit *rest.Kit, resourceType iam.TypeID, 
 }
 
 // ListModelInstance list model instances, parent is model
+// todo: 为实现动态模型实例列表的展示, 这里需要修改
 func (lgc *Logics) ListModelInstance(kit *rest.Kit, resourceType iam.TypeID, filter *types.ListInstanceFilter,
 	page types.Page) (*types.ListInstanceResult, error) {
 

--- a/src/scene_server/auth_server/service/service.go
+++ b/src/scene_server/auth_server/service/service.go
@@ -36,14 +36,16 @@ import (
 type AuthService struct {
 	engine     *backbone.Engine
 	iamClient  client.Interface
+	acIam      *iam.Iam
 	lgc        *logics.Logics
 	authorizer sdkauth.Authorizer
 }
 
-func NewAuthService(engine *backbone.Engine, iamClient client.Interface, lgc *logics.Logics, authorizer sdkauth.Authorizer) *AuthService {
+func NewAuthService(engine *backbone.Engine, iamClient client.Interface, acIam *iam.Iam, lgc *logics.Logics, authorizer sdkauth.Authorizer) *AuthService {
 	return &AuthService{
 		engine:     engine,
 		iamClient:  iamClient,
+		acIam:      acIam,
 		lgc:        lgc,
 		authorizer: authorizer,
 	}
@@ -194,6 +196,18 @@ func (s *AuthService) initAuth(api *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/permission_to_apply", Handler: s.GetPermissionToApply})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/register/resource_creator_action", Handler: s.RegisterResourceCreatorAction})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/register/batch_resource_creator_action", Handler: s.BatchRegisterResourceCreatorAction})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/register/model_resource_types", Handler: s.RegisterModelResourceTypes})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/unregister/model_resource_types", Handler: s.UnregisterModelResourceTypes})
+	// 增量注册instance_selections
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/register/model_instance_selections", Handler: s.RegisterModelInstanceSelections})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/unregister/model_instance_selections", Handler: s.UnregisterModelInstanceSelections})
+	// 增量注册actions
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/model_instance_actions", Handler: s.CreateModelInstanceActions})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/delete/model_instance_actions", Handler: s.DeleteModelInstanceActions})
+	// 全量更新IAM内的action_groups
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/update/model_instance_action_groups", Handler: s.UpdateModelInstanceActionGroups})
+	// 目前还没有使用到"sync/model_instance_actions"接口, 以后可能有用
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/sync/model_instance_actions", Handler: s.SyncIAMModelResourcesCall})
 
 	utility.AddToRestfulWebService(api)
 }

--- a/src/scene_server/auth_server/service/syncAction.go
+++ b/src/scene_server/auth_server/service/syncAction.go
@@ -1,0 +1,200 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"configcenter/src/ac/iam"
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/http/rest"
+	"configcenter/src/common/util"
+	"configcenter/src/scene_server/auth_server/app/options"
+)
+
+type SyncServer struct {
+	Config  *options.Config
+	Service *AuthService
+}
+
+// 根据配置文件, 每隔固定时间就同步下IAM的action列表, 将IAM中多余的action删除。
+func (s *AuthService) LoopSyncActionWithIAM(ctx context.Context, config *options.Config) {
+	kit := s.NewKit(config)
+	timer := time.NewTimer(config.Auth.Interval)
+	for true {
+		select {
+		// 计时器信号
+		case <-timer.C:
+			err := s.SyncIAMModelResources(*kit)
+			if err != nil {
+				blog.Errorf("sync action with IAM failed, err:%v", err)
+			}
+		// authServer退出信号
+		case <-ctx.Done():
+			blog.Infof("auth server will exit!")
+			return
+		}
+	}
+}
+
+// NewHeader
+func (s *AuthService) NewHeader(config *options.Config) http.Header {
+	header := make(http.Header)
+	header.Add(common.BKHTTPOwnerID, common.BKSuperOwnerID)
+	header.Add(common.BKHTTPHeaderUser, common.BKAuthUser)
+	header.Add(common.BKHTTPLanguage, "cn")
+	header.Add(common.BKHTTPCCRequestID, util.GenerateRID())
+	header.Add("Content-Type", "application/json")
+
+	header.Add(iam.IamAppCodeHeader, config.Auth.AppCode)
+	header.Add(iam.IamAppSecretHeader, config.Auth.AppSecret)
+	return header
+}
+
+// NewKit
+func (s *AuthService) NewKit(config *options.Config) *rest.Kit {
+	header := s.NewHeader(config)
+
+	ctx := util.NewContextFromHTTPHeader(header)
+	rid := util.GetHTTPCCRequestID(header)
+	user := util.GetUser(header)
+	supplierAccount := util.GetOwnerID(header)
+	defaultCCError := util.GetDefaultCCError(header)
+
+	return &rest.Kit{
+		Rid:             rid,
+		Header:          header,
+		Ctx:             ctx,
+		CCError:         defaultCCError,
+		User:            user,
+		SupplierAccount: supplierAccount,
+	}
+}
+
+// SyncIAMModelResources check iam dynamic-model resources with CC models.
+// In most cases, this func will unregister IAM model resources which are discard.
+func (s *AuthService) SyncIAMModelResources(kit rest.Kit) error {
+
+	// Direct call IAM, get infos from iam.
+	sysResp, err := s.acIam.Client.GetSystemDynamicInfo(kit.Ctx)
+	if err != nil {
+		blog.ErrorJSON("Synchronize actions with IAM failed, get resource actions from IAM failed, error: %s, resource actions: %s, rid: %s", err.Error(), sysResp, kit.Rid)
+		return err
+	}
+
+	// 这是有顺序的1.ActionGroup 2.Action 3.InstanceSelection 4.ResourceType
+	if staticActionGroupList == nil {
+		staticActionGroupList = iam.GenerateStaticActionGroups()
+	}
+	if staticActionList == nil {
+		staticActionList = iam.GenerateStaticActions()
+	}
+	if staticInstanceSelectionList == nil {
+		staticInstanceSelectionList = iam.GenerateStaticInstanceSelections()
+	}
+	if staticResourceTypeList == nil {
+		staticResourceTypeList = iam.GenerateStaticResourceTypes()
+	}
+
+	// 需要先拿到当前已存在的模型, 再与IAM返回结果进行对比
+	models, err := s.lgc.CollectObjectsNotPre(&kit)
+	if err != nil {
+		blog.Errorf("Synchronize actions with IAM failed, collect notPre-models failed, err: %s, rid:%s", err.Error(), kit.Rid)
+		return err
+	}
+
+	cmdbActionGroupList := append(staticActionGroupList, iam.GenModelInstanceManageActionGroups(models)...)
+	cmdbActionList := append(staticActionList, iam.GenModelInstanceActions(models)...)
+	cmdbInstanceSelectionList := append(staticInstanceSelectionList, iam.GenDynamicInstanceSelectionWithModel(models)...)
+	cmdbResourceTypeList := append(staticResourceTypeList, iam.GenDynamicResourceTypeWithModel(models)...)
+
+	// 筛选需要删除的对象, 其中ActionGroup是全量同步, 不需要此步骤
+	deleteActionList := checkActionList(cmdbActionList, sysResp.Data.Actions)
+	deleteInstanceSelectionList := checkInstanceSelectionList(cmdbInstanceSelectionList, sysResp.Data.InstanceSelections)
+	deleteResourceTypeList := checkResourceTypeList(cmdbResourceTypeList, sysResp.Data.ResourceTypes)
+
+	// 1.Direct call IAM, update action_groups in iam
+	if err := s.acIam.Client.UpdateActionGroups(kit.Ctx, cmdbActionGroupList); err != nil {
+		blog.ErrorJSON("Synchronize actions with IAM failed, delete IAM actions failed, error: %s, resource actions: %s, rid:%s", err.Error(), deleteActionList, kit.Rid)
+		return err
+	}
+	// 2.Direct call IAM, delete certain actions in iam
+	if err := s.acIam.Client.DeleteAction(kit.Ctx, deleteActionList); err != nil {
+		blog.ErrorJSON("Synchronize actions with IAM failed, delete IAM actions failed, error: %s, resource actions: %s, rid:%s", err.Error(), deleteActionList, kit.Rid)
+		return err
+	}
+	// 3.Direct call IAM, delete certain InstanceSelections in iam
+	if err := s.acIam.Client.DeleteInstanceSelection(kit.Ctx, deleteInstanceSelectionList); err != nil {
+		blog.ErrorJSON("Synchronize actions with IAM failed, delete IAM actions failed, error: %s, resource actions: %s, rid:%s", err.Error(), deleteActionList, kit.Rid)
+		return err
+	}
+	// 4.Direct call IAM, delete certain ResourceTypes in iam
+	if err := s.acIam.Client.DeleteResourcesTypes(kit.Ctx, deleteResourceTypeList); err != nil {
+		blog.ErrorJSON("Synchronize actions with IAM failed, delete IAM actions failed, error: %s, resource actions: %s, rid:%s", err.Error(), deleteActionList, kit.Rid)
+		return err
+	}
+	return nil
+}
+
+func checkActionList(cmdbActionList []iam.ResourceAction, iamActionList []iam.ResourceAction) []iam.ActionID {
+	// 由整体的cmdbAction列表转换为cmdbAction集合
+	cmdbActionMap := map[iam.ActionID]struct{}{}
+	for _, act := range cmdbActionList {
+		cmdbActionMap[act.ID] = struct{}{}
+	}
+
+	// 对比出IAM中多余的动作
+	deleteActionList := []iam.ActionID{}
+	for _, act := range iamActionList {
+		if _, exists := cmdbActionMap[act.ID]; exists {
+			continue
+		}
+		deleteActionList = append(deleteActionList, act.ID)
+	}
+	return deleteActionList
+}
+
+func checkInstanceSelectionList(cmdbInstanceSelectionList []iam.InstanceSelection, iamInstanceSelectionList []iam.InstanceSelection) []iam.InstanceSelectionID {
+	cmdbInstanceSelectionMap := map[iam.InstanceSelectionID]struct{}{}
+	for _, instSelection := range cmdbInstanceSelectionList {
+		cmdbInstanceSelectionMap[instSelection.ID] = struct{}{}
+	}
+
+	deleteInstanceSelectionList := []iam.InstanceSelectionID{}
+	for _, instSelection := range iamInstanceSelectionList {
+		if _, exists := cmdbInstanceSelectionMap[instSelection.ID]; exists {
+			continue
+		}
+		deleteInstanceSelectionList = append(deleteInstanceSelectionList, instSelection.ID)
+	}
+	return deleteInstanceSelectionList
+}
+
+func checkResourceTypeList(cmdbResourceTypeList []iam.ResourceType, iamResourceTypeList []iam.ResourceType) []iam.TypeID {
+	cmdbResourceTypeMap := map[iam.TypeID]struct{}{}
+	for _, resourceType := range cmdbResourceTypeList {
+		cmdbResourceTypeMap[resourceType.ID] = struct{}{}
+	}
+
+	deleteResourceTypeList := []iam.TypeID{}
+	for _, resourceType := range iamResourceTypeList {
+		if _, exists := cmdbResourceTypeMap[resourceType.ID]; exists {
+			continue
+		}
+		deleteResourceTypeList = append(deleteResourceTypeList, resourceType.ID)
+	}
+	return deleteResourceTypeList
+}

--- a/src/scene_server/topo_server/core/operation/association_mainline_object.go
+++ b/src/scene_server/topo_server/core/operation/association_mainline_object.go
@@ -71,7 +71,7 @@ func (assoc *association) DeleteMainlineAssociation(kit *rest.Kit, objID string)
 	}
 
 	// delete objects
-	if err = assoc.obj.DeleteObject(kit, tObject.ID, false); nil != err && io.EOF != err {
+	if _, err = assoc.obj.DeleteObject(kit, tObject.ID, false); nil != err && io.EOF != err {
 		blog.Errorf("[operation-asst] failed to delete the object(%s), error info is %s, rid: %s", tObject.ID, err.Error(), kit.Rid)
 		return err
 	}

--- a/src/scene_server/topo_server/core/operation/object.go
+++ b/src/scene_server/topo_server/core/operation/object.go
@@ -41,7 +41,7 @@ type ObjectOperationInterface interface {
 	FindObjectBatch(kit *rest.Kit, objIDs []string) (mapstr.MapStr, error)
 	CreateObject(kit *rest.Kit, isMainline bool, data mapstr.MapStr) (model.Object, error)
 	CanDelete(kit *rest.Kit, targetObj model.Object) error
-	DeleteObject(kit *rest.Kit, id int64, needCheckInst bool) error
+	DeleteObject(kit *rest.Kit, id int64, needCheckInst bool) (*metadata.Object, error)
 	FindObject(kit *rest.Kit, cond condition.Condition) ([]model.Object, error)
 	FindObjectTopo(kit *rest.Kit, cond condition.Condition) ([]metadata.ObjectTopo, error)
 	FindSingleObject(kit *rest.Kit, objectID string) (model.Object, error)
@@ -103,7 +103,7 @@ func (o *object) IsValidObject(kit *rest.Kit, objID string) error {
 }
 
 // CreateObjectBatch manipulate model in cc_ObjDes
-// this method does'nt act as it's name, it create or update model's attributes indeed.
+// this method doesn't act as it's name, it create or update model's attributes indeed.
 // it only operate on model already exist, that it to say no new model will be created.
 func (o *object) CreateObjectBatch(kit *rest.Kit, inputDataMap map[string]ImportObjectData) (mapstr.MapStr, error) {
 	result := mapstr.New()
@@ -544,9 +544,9 @@ func (o *object) CanDelete(kit *rest.Kit, targetObj model.Object) error {
 }
 
 // DeleteObject delete model by id
-func (o *object) DeleteObject(kit *rest.Kit, id int64, needCheckInst bool) error {
+func (o *object) DeleteObject(kit *rest.Kit, id int64, needCheckInst bool) (*metadata.Object, error) {
 	if id <= 0 {
-		return kit.CCError.CCErrorf(common.CCErrCommParamsInvalid, common.BKFieldID)
+		return nil, kit.CCError.CCErrorf(common.CCErrCommParamsInvalid, common.BKFieldID)
 	}
 
 	// get model by id
@@ -555,15 +555,15 @@ func (o *object) DeleteObject(kit *rest.Kit, id int64, needCheckInst bool) error
 	objs, err := o.FindObject(kit, cond)
 	if nil != err {
 		blog.Errorf("[operation-obj] failed to find objects, the condition is (%v) err: %s, rid: %s", cond, err.Error(), kit.Rid)
-		return err
+		return nil, err
 	}
 	// shouldn't return 404 error here, legacy implements just ignore not found error
 	if len(objs) == 0 {
 		blog.V(3).Infof("[operation-obj] object not found, condition: %v, err: %s, rid: %s", cond, err.Error(), kit.Rid)
-		return nil
+		return nil, nil
 	}
 	if len(objs) > 1 {
-		return kit.CCError.CCError(common.CCErrCommGetMultipleObject)
+		return nil, kit.CCError.CCError(common.CCErrCommGetMultipleObject)
 	}
 	obj := objs[0]
 	object := obj.Object()
@@ -571,38 +571,37 @@ func (o *object) DeleteObject(kit *rest.Kit, id int64, needCheckInst bool) error
 	// check whether it can be deleted
 	if needCheckInst {
 		if err := o.CanDelete(kit, obj); nil != err {
-			return err
+			return nil, err
 		}
 	}
 
 	// generate audit log of object.
 	audit := auditlog.NewObjectAuditLog(o.clientSet.CoreService())
 	generateAuditParameter := auditlog.NewGenerateAuditCommonParameter(kit, metadata.AuditDelete)
-	auditLog, err := audit.GenerateAuditLog(generateAuditParameter, obj.Object().ID, nil)
+	auditLog, err := audit.GenerateAuditLog(generateAuditParameter, id, &object)
 	if err != nil {
 		blog.Errorf("generate audit log failed before delete object, objName: %s, err: %v, rid: %s",
 			object.ObjectName, err, kit.Rid)
-		return err
+		return nil, err
 	}
 
 	// DeleteModelCascade 将会删除模型/模型属性/属性分组/唯一校验
 	rsp, err := o.clientSet.CoreService().Model().DeleteModelCascade(kit.Ctx, kit.Header, id)
 	if nil != err {
 		blog.Errorf("[operation-obj] failed to request the object controller, err: %s, rid: %s", err.Error(), kit.Rid)
-		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
+		return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
 	}
 	if !rsp.Result {
 		blog.Errorf("[operation-obj] failed to delete the object by the id(%d), rid: %s", id, kit.Rid)
-		return kit.CCError.New(rsp.Code, rsp.ErrMsg)
+		return nil, kit.CCError.New(rsp.Code, rsp.ErrMsg)
 	}
 
 	// save audit log.
 	if err := audit.SaveAuditLog(kit, *auditLog); err != nil {
 		blog.Errorf("delete object %s success, save audit log failed, err: %v, rid: %s", object.ObjectName, err, kit.Rid)
-		return err
+		return nil, err
 	}
-
-	return nil
+	return &object, nil
 }
 
 func (o *object) isFrom(kit *rest.Kit, fromObjID, toObjID string) (bool, error) {

--- a/src/scene_server/topo_server/service/object.go
+++ b/src/scene_server/topo_server/service/object.go
@@ -128,7 +128,7 @@ func (s *Service) CreateObject(ctx *rest.Contexts) {
 			return err
 		}
 
-		// register object resource creator action to iam
+		// 注册: 1.创建者权限 2.新资源类型 3.新实例视图 4.新鉴权动作 5.新鉴权动作分组
 		if auth.EnableAuthorize() {
 			iamInstance := metadata.IamInstanceWithCreator{
 				Type:    string(iam.SysModel),
@@ -136,7 +136,39 @@ func (s *Service) CreateObject(ctx *rest.Contexts) {
 				Name:    rsp.Object().ObjectName,
 				Creator: ctx.Kit.User,
 			}
+			// 1.register object resource creator action to iam
 			_, err = s.AuthManager.Authorizer.RegisterResourceCreatorAction(ctx.Kit.Ctx, ctx.Kit.Header, iamInstance)
+			if err != nil {
+				blog.Errorf("register created object to iam failed, err: %s, rid: %s", err, ctx.Kit.Rid)
+				return err
+			}
+
+			modelList := []metadata.Object{rsp.Object()}
+			// 2.register new resourceType when new model is created
+			err = s.AuthManager.Authorizer.RegisterModelResourceTypes(ctx.Kit.Ctx, ctx.Kit.Header, modelList)
+			if err != nil {
+				blog.Errorf("register created object to iam failed, err: %s, rid: %s", err, ctx.Kit.Rid)
+				return err
+			}
+
+			// 3.register new instance_selection when new model is created
+			err = s.AuthManager.Authorizer.RegisterModelInstanceSelections(ctx.Kit.Ctx, ctx.Kit.Header, modelList)
+			if err != nil {
+				blog.Errorf("register created object to iam failed, err: %s, rid: %s", err, ctx.Kit.Rid)
+				return err
+			}
+
+			// 4.register IAM actions when new model is created
+			err = s.AuthManager.Authorizer.CreateModelInstanceActions(ctx.Kit.Ctx, ctx.Kit.Header, modelList)
+			if err != nil {
+				blog.Errorf("register created object to iam failed, err: %s, rid: %s", err, ctx.Kit.Rid)
+				return err
+			}
+			time.Sleep(time.Duration(1) * time.Second)
+
+			// 5.register IAM action groups when new model is created
+			// 注意: 此接口目前为全量更新, IAM暂时没有提供增量更新接口
+			err = s.AuthManager.Authorizer.UpdateModelInstanceActionGroups(ctx.Kit.Ctx, ctx.Kit.Header)
 			if err != nil {
 				blog.Errorf("register created object to iam failed, err: %s, rid: %s", err, ctx.Kit.Rid)
 				return err
@@ -237,18 +269,66 @@ func (s *Service) DeleteObject(ctx *rest.Contexts) {
 		return
 	}
 
+	obj := &metadata.Object{}
 	//delete model
 	txnErr := s.Engine.CoreAPI.CoreService().Txn().AutoRunTxn(ctx.Kit.Ctx, ctx.Kit.Header, func() error {
-		err = s.Core.ObjectOperation().DeleteObject(ctx.Kit, id, true)
+		obj, err = s.Core.ObjectOperation().DeleteObject(ctx.Kit, id, true)
 		if err != nil {
 			return err
 		}
+		// 事务内部可以允许不多于一个的其它系统调用函数, 排在事务尾部, 仍可保证原子性
+		// 由于ActionGroups会直观的让用户在IAM内看到访问界面的变化, 应尽量优先保证与cmdb操作的事务性
+		// 1.update IAM action groups
+		if auth.EnableAuthorize() {
+			err = s.AuthManager.Authorizer.UpdateModelInstanceActionGroups(ctx.Kit.Ctx, ctx.Kit.Header)
+			if err != nil {
+				blog.Errorf("[api-obj] delete model, but update instance action group to iam failed, err: %s, rid: %s", err, ctx.Kit.Rid)
+				return err
+			}
+		}
 		return nil
 	})
-
 	if txnErr != nil {
 		ctx.RespAutoError(txnErr)
 		return
+	}
+
+	// 如果注销操作有部分成功, 然后失败; 此时cmdb数据如果回滚会导致IAM的数据出现不可预知的情况; 故此处操作不能实现事务
+	// 此处的注销操作如果失败, 仍可依赖周期性任务[此任务挂在authServer进程上]保证IAM数据同步
+	if auth.EnableAuthorize() {
+		objList := []metadata.Object{*obj}
+		// 2.delete action
+		err = s.AuthManager.Authorizer.DeleteModelInstanceActions(ctx.Kit.Ctx, ctx.Kit.Header, objList)
+		if err != nil {
+			blog.Errorf("[api-obj] delete model, but unregister actions failed, err: %s, rid: %s", err, ctx.Kit.Rid)
+
+			// 这里的失败, 用户是无感知的, 可依赖周期性任务实现最终一致
+			// ctx.RespAutoError(ctx.Kit.CCError.CCErrorf(common.CCErrCommUnRegistResourceToIAMFailed))
+			ctx.RespEntity(nil)
+			return
+		}
+
+		// 3.instance selection
+		err = s.AuthManager.Authorizer.UnregisterModelInstanceSelections(ctx.Kit.Ctx, ctx.Kit.Header, objList)
+		if err != nil {
+			blog.Errorf("[api-obj] delete model, but unregister instance selections failed, err: %s, rid: %s", err, ctx.Kit.Rid)
+
+			// 这里的失败, 用户是无感知的, 可依赖周期性任务实现最终一致
+			// ctx.RespAutoError(ctx.Kit.CCError.CCErrorf(common.CCErrCommUnRegistResourceToIAMFailed))
+			ctx.RespEntity(nil)
+			return
+		}
+
+		// 4.unregister resourceType
+		err = s.AuthManager.Authorizer.UnregisterModelResourceTypes(ctx.Kit.Ctx, ctx.Kit.Header, objList)
+		if err != nil {
+			blog.Errorf("[api-obj] delete model, but unregister model resource types failed, err: %s, rid: %s", err, ctx.Kit.Rid)
+
+			// 这里的失败, 用户是无感知的, 可依赖周期性任务实现最终一致
+			// ctx.RespAutoError(ctx.Kit.CCError.CCErrorf(common.CCErrCommUnRegistResourceToIAMFailed))
+			ctx.RespEntity(nil)
+			return
+		}
 	}
 	ctx.RespEntity(nil)
 }

--- a/src/scene_server/topo_server/service/service_business_initfunc.go
+++ b/src/scene_server/topo_server/service/service_business_initfunc.go
@@ -26,6 +26,8 @@ func (s *Service) initBusinessObject(web *restful.WebService) {
 		Language: s.Engine.Language,
 	})
 
+	// todo: CreateObjectBatch 这个函数到底是干嘛的？我在后续的注释中发现了下面这行注释
+	// ----"this method doesn't act as it's name, it create or update model's attributes indeed."
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/createmany/object", Handler: s.CreateObjectBatch})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/object", Handler: s.SearchObjectBatch})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/object", Handler: s.CreateObject})


### PR DESCRIPTION
### 新加的功能:
动态模型实例权限--注册部分
方案如下：
    创建一个模型时：
        按顺序在事务内注册  1.ResourceCreatorAction，2.resourceType，3.instance_selection 4.action，5.actionGroup
    删除一个模型时：
        事务内注销：1.actionGroup
        按顺序事务外注销：2.action 3.instance_selection 4.resource_type
    周期任务：
        周期同步1.actionGroup 2.action 3.instance_selection, 4.resource_type

